### PR TITLE
chore: comment realms for event logs for now

### DIFF
--- a/terraform/keycloak-dev/realm-events.tf
+++ b/terraform/keycloak-dev/realm-events.tf
@@ -1,5 +1,6 @@
 locals {
-  target_realms = ["v45fd2kb"]
+  target_realms = []
+  # target_realms = ["v45fd2kb"]
 }
 
 module "realm_events" {


### PR DESCRIPTION
Let's comment this out until we find the way for the admin privileges for the service account and to avoid any further Terraform run failures.