### PR TITLE
chore: allow to create keycloak resources upto 27

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -136,9 +136,9 @@ jobs:
           plan-result: "${{ steps.plan.outcome }}"
           pr-number: "${{ github.event.number }}"
           pr-branch: "${{ github.event.pull_request.head.ref }}"
-          allowed-additions: "24"
-          allowed-deletions: "24"
-          allowed-updates: "24"
+          allowed-additions: "27"
+          allowed-deletions: "27"
+          allowed-updates: "27"
           allowed-file-changes: "3"
 
       - name: Terraform Plan Status

--- a/.github/workflows/terraform-v2-plan.yml
+++ b/.github/workflows/terraform-v2-plan.yml
@@ -141,9 +141,9 @@ jobs:
           plan-result: "${{ steps.plan.outcome }}"
           pr-number: "${{ github.event.number }}"
           pr-branch: "${{ github.event.pull_request.head.ref }}"
-          allowed-additions: "24"
-          allowed-deletions: "24"
-          allowed-updates: "24"
+          allowed-additions: "27"
+          allowed-deletions: "27"
+          allowed-updates: "27"
           allowed-file-changes: "3"
 
       - name: Terraform Plan Status


### PR DESCRIPTION
- increase the allowed Keycloak resource quota as the increased number of client mappers.