### PR TITLE
chore: deploy from dev

### DIFF
--- a/terraform-v2/keycloak-dev/main.tf
+++ b/terraform-v2/keycloak-dev/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "standard" {
-  source       = "github.com/bcgov/sso-terraform-modules?ref=main/modules/base-realms/realm-standard"
+  source       = "github.com/bcgov/sso-terraform-modules?ref=dev/modules/base-realms/realm-standard"
   keycloak_url = var.keycloak_url
 
   standard_realm_name      = local.standard_realm_name

--- a/terraform-v2/keycloak-test/main.tf
+++ b/terraform-v2/keycloak-test/main.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "standard" {
-  source       = "github.com/bcgov/sso-terraform-modules?ref=main/modules/base-realms/realm-standard"
+  source       = "github.com/bcgov/sso-terraform-modules?ref=dev/modules/base-realms/realm-standard"
   keycloak_url = var.keycloak_url
 
   standard_realm_name      = local.standard_realm_name


### PR DESCRIPTION
Temporarily deploy standard realm configuration for the dev and test environments from the dev branch of sso-terraform-modules. This will create the client-stopper auth flow so that DC can be tested out. Note that merging dev -> main in sso-terraform-modules would break production since the required authenticator for the client-stopper flow does not exists there yet.