### PR TITLE
chore: cache

### DIFF
--- a/.github/workflows/terraform-v2-apply.yml
+++ b/.github/workflows/terraform-v2-apply.yml
@@ -16,14 +16,12 @@ jobs:
     - uses: hmarr/debug-action@v3
 
     - name: Checkout Terraform Modules
-      if: steps.count.outputs.count != '0'
       uses: actions/checkout@v4
       with:
         repository: bcgov/sso-terraform-modules
         ref: main
 
     - id: tf-modules
-      if: steps.count.outputs.count != '0'
       name: Get Terraform Modules Latest SHA
       run: echo "latest-sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/terraform-v2-apply.yml
+++ b/.github/workflows/terraform-v2-apply.yml
@@ -64,10 +64,16 @@ jobs:
         prod-azureidir-client-secret: ${{ secrets.PROD_AZUREIDIR_CLIENT_SECRET }}
         dev-github-client-id: ${{ secrets.DEV_GITHUB_CLIENT_ID }}
         dev-github-client-secret: ${{ secrets.DEV_GITHUB_CLIENT_SECRET }}
+        dev-digitalcredential-client-id: ${{ secrets.DEV_DIGITALCREDENTIAL_CLIENT_ID }}
+        dev-digitalcredential-client-secret: ${{ secrets.DEV_DIGITALCREDENTIAL_CLIENT_SECRET }}
         test-github-client-id: ${{ secrets.TEST_GITHUB_CLIENT_ID }}
         test-github-client-secret: ${{ secrets.TEST_GITHUB_CLIENT_SECRET }}
+        test-digitalcredential-client-id: ${{ secrets.TEST_DIGITALCREDENTIAL_CLIENT_ID }}
+        test-digitalcredential-client-secret: ${{ secrets.TEST_DIGITALCREDENTIAL_CLIENT_SECRET }}
         prod-github-client-id: ${{ secrets.PROD_GITHUB_CLIENT_ID }}
         prod-github-client-secret: ${{ secrets.PROD_GITHUB_CLIENT_SECRET }}
+        prod-digitalcredential-client-id: ${{ secrets.PROD_DIGITALCREDENTIAL_CLIENT_ID }}
+        prod-digitalcredential-client-secret: ${{ secrets.PROD_DIGITALCREDENTIAL_CLIENT_SECRET }}
         apply: true
         tf-modules-cache-key: ${{ steps.tf-modules.outputs.latest-sha }}
 


### PR DESCRIPTION
I think the caching logic is being skipped here since there is no step called count. I believe this hasn't been noticed before because caches only live [7 days](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) and we don't update modules for production that frequently. 

Since we redeployed for the new auth flow 4 days ago, seems to just be reusing that cache now when attempting to update the error url