### PR TITLE
chore: set default scopes

### DIFF
--- a/terraform-modules/modules/base-realms/realm-standard/realm.tf
+++ b/terraform-modules/modules/base-realms/realm-standard/realm.tf
@@ -19,12 +19,12 @@ module "realm" {
 }
 
 resource "keycloak_realm_default_client_scopes" "default_scopes" {
-  realm_id = module.realm.id
+  realm_id       = module.realm.id
   default_scopes = var.default_client_scopes
 }
 
 resource "keycloak_realm_optional_client_scopes" "default_scopes" {
-  realm_id = module.realm.id
+  realm_id        = module.realm.id
   optional_scopes = var.optional_client_scopes
 }
 

--- a/terraform-modules/modules/base-realms/realm-standard/realm.tf
+++ b/terraform-modules/modules/base-realms/realm-standard/realm.tf
@@ -18,6 +18,16 @@ module "realm" {
   offline_session_max_lifespan_enabled = true
 }
 
+resource "keycloak_realm_default_client_scopes" "default_scopes" {
+  realm_id = module.realm.id
+  default_scopes = var.default_client_scopes
+}
+
+resource "keycloak_realm_optional_client_scopes" "default_scopes" {
+  realm_id = module.realm.id
+  optional_scopes = var.optional_client_scopes
+}
+
 module "idp_auth_flow" {
   source   = "../../idp-stopper-auth-flow"
   realm_id = module.realm.id

--- a/terraform-modules/modules/base-realms/realm-standard/variables.tf
+++ b/terraform-modules/modules/base-realms/realm-standard/variables.tf
@@ -121,3 +121,15 @@ variable "ppid_token_url" {
 variable "ppid_issuer" {
   type = string
 }
+
+variable "default_client_scopes" {
+  description = "List of client scopes assigned as default to new clients in the standard realm."
+  type        = list(string)
+  default     = ["profile", "email", "roles", "web-origins", "acr", "basic"]
+}
+
+variable "optional_client_scopes" {
+  description = "List of client scopes assigned as optional to new clients in the standard realm."
+  type        = list(string)
+  default     = ["offline_access", "phone", "microprofile-jwt"]
+}


### PR DESCRIPTION
- explicitly set default and optional scopes in standard realm 
- Set default vars matching current except removal of "address" from the optional list