### PR TITLE
chore: empty config

### DIFF
--- a/terraform-modules/modules/base-realms/realm-otp/idp-otp.tf
+++ b/terraform-modules/modules/base-realms/realm-otp/idp-otp.tf
@@ -22,11 +22,12 @@ resource "keycloak_oidc_identity_provider" "otp" {
 
   backchannel_supported = var.backchannel_supported
 
-  extra_config = {
-    clientAuthMethod  = "client_secret_post"
-    prompt            = "login"
+  extra_config = merge({
+    clientAuthMethod = "client_secret_post"
+    prompt           = "login"
+    }, var.forward_parameters != "" ? {
     forwardParameters = var.forward_parameters
-  }
+  } : {})
 }
 
 resource "keycloak_custom_identity_provider_mapper" "otp_username" {


### PR DESCRIPTION
merge objects to avoid empty configs. Having `forward_parameters = ""`  included in config shows false updates to `null` in the terraform plan, e.g:

```hcl
  # module.otp.keycloak_oidc_identity_provider.otp will be updated in-place
  ~ resource "keycloak_oidc_identity_provider" "otp" {
      ~ extra_config                            = {
          + "forwardParameters" = null
            # (2 unchanged elements hidden)
        }
        id                                      = "otp"
        # (36 unchanged attributes hidden)
    }
 ```   
   even though nothing actually changes. Merging objects to avoid the empty parameter avoids this plan bloat.